### PR TITLE
feat: cache buildUserCtx per user with 5-min TTL

### DIFF
--- a/packages/hosted/src/index.js
+++ b/packages/hosted/src/index.js
@@ -35,7 +35,7 @@ import { rateLimit } from "./middleware/rate-limit.js";
 import { requestLogger } from "./middleware/logger.js";
 import { createManagementRoutes } from "./server/management.js";
 import { createVaultApiRoutes } from "./routes/vault-api.js";
-import { buildUserCtx } from "./server/user-ctx.js";
+import { getCachedUserCtx } from "./server/user-ctx.js";
 import { pool } from "./server/user-db.js";
 import { scheduleBackups, lastBackupTimestamp } from "./backup/r2-backup.js";
 
@@ -118,7 +118,7 @@ async function createMcpServer(user) {
     { name: "context-vault-hosted", version: pkgVersion },
     { capabilities: { tools: {} } }
   );
-  const userCtx = await buildUserCtx(ctx, user, VAULT_MASTER_SECRET);
+  const userCtx = await getCachedUserCtx(ctx, user, VAULT_MASTER_SECRET);
   registerTools(server, userCtx);
   return server;
 }

--- a/packages/hosted/src/routes/vault-api.js
+++ b/packages/hosted/src/routes/vault-api.js
@@ -26,7 +26,7 @@ import { normalizeKind } from "@context-vault/core/core/files";
 import { categoryFor } from "@context-vault/core/core/categories";
 import { isOverEntryLimit } from "../billing/stripe.js";
 import { validateEntryInput } from "../validation/entry-validation.js";
-import { buildUserCtx } from "../server/user-ctx.js";
+import { getCachedUserCtx } from "../server/user-ctx.js";
 import { bearerAuth } from "../middleware/auth.js";
 import { rateLimit } from "../middleware/rate-limit.js";
 import { generateOpenApiSpec } from "../api/openapi.js";
@@ -104,7 +104,7 @@ export function createVaultApiRoutes(ctx, masterSecret) {
   api.get("/api/vault/entries", async (c) => {
     const user = c.get("user");
     const teamId = c.req.query("team_id") || null;
-    const userCtx = await buildUserCtx(ctx, user, masterSecret, teamId ? { teamId } : null);
+    const userCtx = await getCachedUserCtx(ctx, user, masterSecret, teamId ? { teamId } : null);
 
     const kind = c.req.query("kind") || null;
     const category = c.req.query("category") || null;
@@ -159,7 +159,7 @@ export function createVaultApiRoutes(ctx, masterSecret) {
 
   api.get("/api/vault/entries/:id", async (c) => {
     const user = c.get("user");
-    const userCtx = await buildUserCtx(ctx, user, masterSecret);
+    const userCtx = await getCachedUserCtx(ctx, user, masterSecret);
     const id = c.req.param("id");
 
     const entry = userCtx.stmts.getEntryById.get(id);
@@ -177,7 +177,7 @@ export function createVaultApiRoutes(ctx, masterSecret) {
 
   api.post("/api/vault/entries", async (c) => {
     const user = c.get("user");
-    const userCtx = await buildUserCtx(ctx, user, masterSecret);
+    const userCtx = await getCachedUserCtx(ctx, user, masterSecret);
 
     const data = await c.req.json().catch(() => null);
     if (!data) return c.json({ error: "Invalid JSON body", code: "INVALID_INPUT" }, 400);
@@ -229,7 +229,7 @@ export function createVaultApiRoutes(ctx, masterSecret) {
 
   api.put("/api/vault/entries/:id", async (c) => {
     const user = c.get("user");
-    const userCtx = await buildUserCtx(ctx, user, masterSecret);
+    const userCtx = await getCachedUserCtx(ctx, user, masterSecret);
     const id = c.req.param("id");
 
     const data = await c.req.json().catch(() => null);
@@ -286,7 +286,7 @@ export function createVaultApiRoutes(ctx, masterSecret) {
 
   api.delete("/api/vault/entries/:id", async (c) => {
     const user = c.get("user");
-    const userCtx = await buildUserCtx(ctx, user, masterSecret);
+    const userCtx = await getCachedUserCtx(ctx, user, masterSecret);
     const id = c.req.param("id");
 
     const entry = userCtx.stmts.getEntryById.get(id);
@@ -318,7 +318,7 @@ export function createVaultApiRoutes(ctx, masterSecret) {
 
   api.post("/api/vault/search", async (c) => {
     const user = c.get("user");
-    const userCtx = await buildUserCtx(ctx, user, masterSecret);
+    const userCtx = await getCachedUserCtx(ctx, user, masterSecret);
 
     const data = await c.req.json().catch(() => null);
     if (!data) return c.json({ error: "Invalid JSON body", code: "INVALID_INPUT" }, 400);
@@ -358,7 +358,7 @@ export function createVaultApiRoutes(ctx, masterSecret) {
 
   api.post("/api/vault/import/bulk", bearerAuth(), rateLimit(), async (c) => {
     const user = c.get("user");
-    const userCtx = await buildUserCtx(ctx, user, masterSecret);
+    const userCtx = await getCachedUserCtx(ctx, user, masterSecret);
 
     const data = await c.req.json().catch(() => null);
     if (!data || !Array.isArray(data.entries)) {
@@ -422,7 +422,7 @@ export function createVaultApiRoutes(ctx, masterSecret) {
 
   api.post("/api/vault/ingest", bearerAuth(), rateLimit(), async (c) => {
     const user = c.get("user");
-    const userCtx = await buildUserCtx(ctx, user, masterSecret);
+    const userCtx = await getCachedUserCtx(ctx, user, masterSecret);
 
     const data = await c.req.json().catch(() => null);
     if (!data?.url) return c.json({ error: "url is required", code: "INVALID_INPUT" }, 400);
@@ -445,7 +445,7 @@ export function createVaultApiRoutes(ctx, masterSecret) {
 
   api.get("/api/vault/manifest", bearerAuth(), rateLimit(), async (c) => {
     const user = c.get("user");
-    const userCtx = await buildUserCtx(ctx, user, masterSecret);
+    const userCtx = await getCachedUserCtx(ctx, user, masterSecret);
 
     const clauses = ["(expires_at IS NULL OR expires_at > datetime('now'))"];
     const params = [];
@@ -462,7 +462,7 @@ export function createVaultApiRoutes(ctx, masterSecret) {
 
   api.get("/api/vault/status", async (c) => {
     const user = c.get("user");
-    const userCtx = await buildUserCtx(ctx, user, masterSecret);
+    const userCtx = await getCachedUserCtx(ctx, user, masterSecret);
 
     const status = gatherVaultStatus(userCtx, { userId: userCtx.userId });
 


### PR DESCRIPTION
## Summary
- Adds `getCachedUserCtx()` in `user-ctx.js` — a drop-in cached wrapper around `buildUserCtx()` with a 5-minute TTL, keyed by `userId:teamId`
- Replaces all 14 `buildUserCtx` call sites across `index.js`, `vault-api.js`, and `management.js`
- Cache is invalidated on tier changes (Stripe checkout + subscription deletion webhooks) and account deletion

## Motivation
Every REST endpoint was rebuilding the full user context per request — allocating new encrypt/decrypt/checkLimits closures and re-running `pool.get()` + `getTierLimits()`. For burst traffic from the same user, this is pure waste.

Fixes #14

## Test plan
- [x] All 386 existing tests pass
- [ ] Deploy to staging, verify repeated API calls from same user hit cache (log or debug check)
- [ ] Verify tier upgrade (Stripe webhook) invalidates cache and next request sees new limits
- [ ] Verify account deletion clears cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 1 queued — [View all](https://hub.continue.dev/inbox/pr/fellanH/context-vault/16?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->