### PR TITLE
Add GTM backlog and workflow to session protocol

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -30,13 +30,15 @@
 Every Claude Code working session follows this workflow:
 
 ### 1. Orient
-- Read `BACKLOG.md` to understand current priorities
-- Check `Now` section for active work items
+- Read `BACKLOG.md` to understand current engineering priorities
+- For GTM sessions: also read `docs/gtm/GTM-BACKLOG.md` and `docs/gtm/GTM-CONTEXT.md`
+- Check `Now` section for active work items (in whichever backlog applies)
 - Query context vault for recent sessions and decisions: `get_context` with tags `context-vault`
 
 ### 2. Pick
 - Work on an item from `Now`, or triage if the user requests it
 - If `Now` is empty, pull the highest-ICE item from `Next`
+- For GTM work: pick from `docs/gtm/GTM-BACKLOG.md` instead
 
 ### 3. Pitch
 Present the plan for user approval **before writing any code**. Scale depth to complexity:
@@ -55,6 +57,7 @@ Wait for explicit user approval before moving to Branch.
 ### 4. Branch
 - Create a branch: `feat/<name>`, `fix/<name>`, or `chore/<name>`
 - Direct commits to `main` only for single-line fixes or docs
+- GTM tasks that produce no code changes skip this step
 
 ### 5. Work
 - Implement, test, commit with conventional commit messages
@@ -117,9 +120,35 @@ End-of-session retrospective. Scale depth to session complexity:
 - Re-score `Next` items if priorities shifted
 - Pull top items into `Now` (max 3)
 
+### GTM Task Workflow
+
+GTM tasks follow the same session protocol but differ in execution:
+
+| Step | Engineering | GTM |
+|------|------------|-----|
+| Orient | Read `BACKLOG.md` | Read `GTM-BACKLOG.md` + `GTM-CONTEXT.md` |
+| Pick | Pull from Now/Next | Same |
+| Pitch | Plan before code | Plan before action (what, where, expected outcome) |
+| Branch | Create git branch | Skip unless task produces code |
+| Work | Code + test + commit | Draft, review, publish, or configure |
+| Ship | PR + merge | Post/publish/submit + verify live |
+| Update | Update BACKLOG.md | Update GTM-BACKLOG.md + weekly-log.md |
+| Review | Session retro | Same format, add `gtm` tag |
+
+**GTM "Ship" definitions by type:**
+- **Distribution:** post is live, link verified
+- **Onboarding:** walkthrough complete, bugs filed
+- **Instrumentation:** events firing in production
+- **Community:** channel created and linked from README
+- **Sales:** asset committed in `docs/gtm/`
+
+**When GTM work requires code** (instrumentation, landing page edits): use full engineering workflow with branch + PR. GTM backlog item stays open until both code ships AND GTM outcome is verified.
+
 ## GTM Context
 
-For marketing, sales, and content work, read `docs/gtm/GTM-CONTEXT.md` which contains ICP, CTAs, content pillars, and the GTM docs index.
+For marketing, sales, and content work:
+- **Backlog:** `docs/gtm/GTM-BACKLOG.md` — prioritized GTM tasks (Now/Next/Later with ICE scoring)
+- **Context:** `docs/gtm/GTM-CONTEXT.md` — ICP, CTAs, content pillars, and GTM docs index
 
 # currentDate
 Today's date is 2026-02-20.

--- a/docs/gtm/GTM-BACKLOG.md
+++ b/docs/gtm/GTM-BACKLOG.md
@@ -1,0 +1,96 @@
+# GTM Backlog
+
+**Last triaged:** 2026-02-20
+
+---
+
+## Now
+
+Active work. Hard cap: 3 items. Finish or demote before adding.
+
+| Item | Type | Source |
+|------|------|--------|
+| Ship Campaign A distribution (X thread, Reddit, HN) | distribution | `sales-assets.md` — drafts ready |
+| Record demo GIF for landing page product-proof section | content | `marketing-plan.md` — product-proof gap |
+| Submit to awesome-mcp list | distribution | Community discovery channel |
+
+---
+
+## Done
+
+_Only the latest batch. Older items archived — see `weekly-log.md` and git history for full record._
+
+| Item | Type | Date |
+|------|------|------|
+| _Nothing shipped yet — GTM backlog just created_ | — | — |
+
+---
+
+## Next
+
+Ordered by ICE score (Impact × Confidence × Ease). Pull from top when `Now` has space.
+
+| Item | Type | ICE | I | C | E | Milestone |
+|------|------|-----|---|---|---|-----------|
+| Show HN post | distribution | 75 | 5 | 5 | 3 | GTM blitz |
+| Stress-test fresh install (npm i → first save_context < 2 min) | onboarding | 60 | 5 | 4 | 3 | Onboarding funnel |
+| Instrument funnel events (lp_view → register → first_save → checkout_success) | instrumentation | 48 | 4 | 4 | 3 | Feedback loop |
+| Set up GitHub Discussions for user feedback | community | 40 | 4 | 5 | 2 | Feedback loop |
+| Draft "why pay" pricing narrative for /pricing page | sales | 36 | 4 | 3 | 3 | Hosted revenue |
+| Post to r/ClaudeAI and r/cursor subreddits | distribution | 30 | 3 | 5 | 2 | GTM blitz |
+| Add in-product feedback prompt (post-activation) | community | 24 | 4 | 3 | 2 | Feedback loop |
+| Evaluate re-ranking strategies for search results | search-quality | 20 | 4 | 5 | 1 | Search quality |
+| Explore better embedding model options | search-quality | 16 | 4 | 4 | 1 | Search quality |
+
+---
+
+## Later
+
+Parking lot. No commitment, no ordering.
+
+- Discord community server
+- Product Hunt launch
+- Paid acquisition experiments (Reddit ads, Carbon ads)
+- Campaigns B & C (drafts in `sales-assets.md`)
+- CRO A/B tests on landing page
+- Comparison landing pages (vs Mem, vs Obsidian, vs static .md files)
+
+---
+
+## Signals
+
+Raw user feedback, community mentions, distribution opportunities. Review weekly during triage.
+
+| Date | Signal | Source | Action |
+|------|--------|--------|--------|
+| — | _No signals yet. Check vault `feedback` entries and GitHub issues weekly._ | — | — |
+
+---
+
+## Decisions
+
+Key GTM choices. Reference, not action items.
+
+| Date | Decision | Reasoning |
+|------|----------|-----------|
+| 2026-02-20 | Content pieces tracked in `content-tracker.md`, not here | GTM backlog is for strategic/structural tasks. Individual blog posts, videos, and BIP updates stay in the content tracker to avoid duplication. |
+| 2026-02-20 | GTM blitz before onboarding optimization | Need traffic to measure the funnel. Ship distribution first, then instrument and optimize. |
+| 2026-02-20 | ICE scoring calibrated for GTM context | Impact = adoption/revenue lift. Confidence = user signal strength. Ease = session count to ship. |
+
+---
+
+## Cross-Reference: GTM Docs
+
+How this backlog relates to other GTM docs in `docs/gtm/`:
+
+| File | Relationship |
+|------|-------------|
+| `GTM-CONTEXT.md` | ICP, CTAs, content pillars — the strategic foundation this backlog executes against |
+| `content-tracker.md` | Individual content pieces (blog, video, BIP). GTM backlog tracks the strategic tasks; content tracker tracks production status. |
+| `weekly-log.md` | Execution journal. When a GTM backlog item ships, record it in the weekly log too. |
+| `pipeline.md` | Founder-led sales CRM. GTM backlog may generate leads that flow into the pipeline. |
+| `sales-playbook.md` | Core pitch and objection handling. Informs GTM backlog items like the pricing narrative. |
+| `sales-assets.md` | Campaign drafts and collateral. GTM backlog items reference assets here; don't duplicate content. |
+| `funnel-metrics.md` | Numeric targets. Instrumentation items in this backlog feed data into funnel metrics. |
+| `assets/` | Campaign drafts (X threads, Reddit posts, HN posts). GTM backlog "Ship Campaign A" pulls from here. |
+| `demos/` | Demo video scripts. GTM backlog "Record demo GIF" may reference scripts here. |

--- a/docs/gtm/GTM-CONTEXT.md
+++ b/docs/gtm/GTM-CONTEXT.md
@@ -30,6 +30,7 @@ All go-to-market strategy and tracking docs live in `docs/gtm/`:
 
 | File | Purpose |
 |------|---------|
+| `GTM-BACKLOG.md` | Prioritized GTM tasks (Now/Next/Later) with ICE scoring — start here for GTM sessions |
 | `marketing-plan.md` | Landing page architecture, SEO, events, CRO backlog |
 | `content-tracker.md` | Status of all 32 content pieces (blog, video, BIP) |
 | `weekly-log.md` | Execution journal and weekly scorecard |


### PR DESCRIPTION
## Summary

- **Create** `docs/gtm/GTM-BACKLOG.md` — prioritized GTM backlog with Now/Next/Later + ICE scoring, seeded with 3 active items (Campaign A, demo GIF, awesome-mcp) and 9 ranked Next items across 5 milestones
- **Update** `.claude/CLAUDE.md` — session protocol now routes GTM sessions through the GTM backlog, with a comparison table and GTM-specific "ship" definitions
- **Update** `docs/gtm/GTM-CONTEXT.md` — add GTM-BACKLOG.md as first entry in the docs index

## Test plan

- [x] Read `docs/gtm/GTM-BACKLOG.md` — confirm Now has 3 items, Next is ICE-ordered, cross-reference table covers all GTM docs
- [x] Read `.claude/CLAUDE.md` — confirm Orient/Pick/Branch steps reference GTM backlog, GTM Task Workflow section is present
- [x] Read `docs/gtm/GTM-CONTEXT.md` — confirm docs index includes GTM-BACKLOG.md as first entry
- [ ] Start a fresh session and say "let's work on GTM" — Orient step should pull from GTM-BACKLOG.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 1 queued — [View all](https://hub.continue.dev/inbox/pr/fellanH/context-vault/20?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->