### PR TITLE
chore: add claude code hooks for file protection and auto-test

### DIFF
--- a/.claude/hooks/auto-test.sh
+++ b/.claude/hooks/auto-test.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# PostToolUse hook: run npm test when a source file in core/local/hosted is edited
+# Skips test files (handled by global hook) and non-source paths
+
+set -euo pipefail
+
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+
+if [[ -z "$FILE_PATH" ]]; then
+  exit 0
+fi
+
+# Only fire on source files in core/local/hosted packages
+if ! echo "$FILE_PATH" | grep -qE 'packages/(core|local|hosted)/src/.+\.js$'; then
+  exit 0
+fi
+
+# Skip test and spec files (global hook handles those)
+if echo "$FILE_PATH" | grep -qE '\.(test|spec)\.js$'; then
+  exit 0
+fi
+
+echo "Running tests for edited source file: $FILE_PATH"
+cd "$(git rev-parse --show-toplevel)"
+npm test 2>&1 | tail -20
+
+exit 0

--- a/.claude/hooks/protect-files.sh
+++ b/.claude/hooks/protect-files.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# PreToolUse hook: block writes to protected files, warn on CHANGELOG
+# Receives JSON on stdin; exit 2 + stderr = block, exit 0 + stdout = warn/allow
+
+set -euo pipefail
+
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+
+if [[ -z "$FILE_PATH" ]]; then
+  exit 0
+fi
+
+# Protected files — block all writes
+PROTECTED=(
+  "packages/core/src/index/db.js"
+  "scripts/release.mjs"
+)
+
+for protected in "${PROTECTED[@]}"; do
+  if [[ "$FILE_PATH" == *"$protected" ]]; then
+    echo "BLOCKED: $FILE_PATH is a protected file. Edit requires explicit user approval." >&2
+    exit 2
+  fi
+done
+
+# CHANGELOG — allow but remind about format
+if [[ "$FILE_PATH" == *"CHANGELOG.md" ]]; then
+  echo "Reminder: CHANGELOG entries must follow '## [X.Y.Z] — YYYY-MM-DD' format."
+  exit 0
+fi
+
+exit 0

--- a/.claude/hooks/stop-verify.sh
+++ b/.claude/hooks/stop-verify.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Stop hook: surface uncommitted changes before Claude finishes
+# Always exits 0 (informational only — does not force Claude to continue)
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+STATUS=$(git status --short)
+
+if [[ -n "$STATUS" ]]; then
+  echo "Uncommitted changes detected:"
+  echo "$STATUS"
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,38 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/protect-files.sh"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/auto-test.sh",
+            "timeout": 90
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/stop-verify.sh",
+            "timeout": 15
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- **PreToolUse** (`protect-files.sh`): blocks writes to `packages/core/src/index/db.js` and `scripts/release.mjs`; warns on `CHANGELOG.md` edits with format reminder
- **PostToolUse** (`auto-test.sh`): runs `npm test` when source files in `core/local/hosted` are edited; skips `.test.js`/`.spec.js` (handled by global hook)
- **Stop** (`stop-verify.sh`): surfaces uncommitted changes before Claude finishes the session (informational, always exits 0)

## Test plan

- [x] `protect-files.sh` exits 2 + stderr for `db.js` and `release.mjs`
- [x] `protect-files.sh` exits 0 + stdout reminder for `CHANGELOG.md`
- [x] `protect-files.sh` exits 0 silently for normal source files
- [x] `auto-test.sh` triggers `npm test` for `packages/core/src/**/*.js` (non-test)
- [x] `auto-test.sh` skips `.test.js` / `.spec.js` files
- [x] `auto-test.sh` skips paths outside core/local/hosted
- [x] `stop-verify.sh` prints dirty files and exits 0; silent + exits 0 on clean repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 1 queued — [View all](https://hub.continue.dev/inbox/pr/fellanH/context-vault/33?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->