### PR TITLE
chore: path-scope CI/deploy workflows + fix staging --prod bug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,33 @@ on:
     branches: [main]
 
 jobs:
-  test-and-build:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      app: ${{ steps.filter.outputs.app }}
+      marketing: ${{ steps.filter.outputs.marketing }}
+      extension: ${{ steps.filter.outputs.extension }}
+      backend: ${{ steps.filter.outputs.backend }}
+      core: ${{ steps.filter.outputs.core }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            app:
+              - 'packages/app/**'
+            marketing:
+              - 'packages/marketing/**'
+            extension:
+              - 'packages/extension/**'
+            backend:
+              - 'packages/hosted/**'
+            core:
+              - 'packages/core/**'
+              - 'test/**'
+
+  test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -16,6 +42,42 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm test
+
+  build-app:
+    needs: [test, changes]
+    runs-on: ubuntu-latest
+    if: needs.changes.outputs.app == 'true' || needs.changes.outputs.core == 'true'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+      - run: npm ci
       - run: npm run build --workspace=packages/app
+
+  build-marketing:
+    needs: [test, changes]
+    runs-on: ubuntu-latest
+    if: needs.changes.outputs.marketing == 'true' || needs.changes.outputs.core == 'true'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+      - run: npm ci
       - run: npm run build --workspace=packages/marketing
+
+  build-extension:
+    needs: [test, changes]
+    runs-on: ubuntu-latest
+    if: needs.changes.outputs.extension == 'true' || needs.changes.outputs.core == 'true'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+      - run: npm ci
       - run: npm run build --workspace=packages/extension

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,20 +3,13 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+    paths:
+      - 'packages/**'
+      - 'test/**'
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    if: github.event.pull_request.draft == false
 
     runs-on: ubuntu-latest
     permissions:
@@ -41,4 +34,3 @@ jobs:
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,9 +20,34 @@ jobs:
     steps:
       - run: echo "CI passed — proceeding with deploy"
 
-  deploy-backend-staging:
+  changes:
     needs: gate
     runs-on: ubuntu-latest
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+      frontends: ${{ steps.filter.outputs.frontends }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+          fetch-depth: 2
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          base: HEAD~1
+          filters: |
+            backend:
+              - 'packages/hosted/**'
+              - 'packages/core/**'
+            frontends:
+              - 'packages/app/**'
+              - 'packages/marketing/**'
+              - 'packages/core/**'
+
+  deploy-backend-staging:
+    needs: [gate, changes]
+    runs-on: ubuntu-latest
+    if: needs.changes.outputs.backend == 'true'
     steps:
       - uses: actions/checkout@v4
       - uses: superfly/flyctl-actions/setup-flyctl@master
@@ -31,8 +56,9 @@ jobs:
           FLY_API_TOKEN: ${{ secrets.STAGING_FLY_API_TOKEN }}
 
   deploy-frontends-staging:
-    needs: gate
+    needs: [gate, changes]
     runs-on: ubuntu-latest
+    if: needs.changes.outputs.frontends == 'true'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -51,7 +77,7 @@ jobs:
       - name: Deploy marketing to Vercel (staging)
         run: |
           cd packages/marketing
-          vercel deploy --prod --token=${{ secrets.VERCEL_TOKEN }} \
+          vercel deploy --token=${{ secrets.VERCEL_TOKEN }} \
             --scope=${{ secrets.VERCEL_ORG_ID }} \
             --yes
         env:
@@ -60,7 +86,7 @@ jobs:
       - name: Deploy app to Vercel (staging)
         run: |
           cd packages/app
-          vercel deploy --prod --token=${{ secrets.VERCEL_TOKEN }} \
+          vercel deploy --token=${{ secrets.VERCEL_TOKEN }} \
             --scope=${{ secrets.VERCEL_ORG_ID }} \
             --yes
         env:
@@ -70,6 +96,7 @@ jobs:
   health-staging:
     needs: [deploy-backend-staging, deploy-frontends-staging]
     runs-on: ubuntu-latest
+    if: always() && (needs.deploy-backend-staging.result == 'success' || needs.deploy-frontends-staging.result == 'success')
     steps:
       - name: Wait for staging health
         run: |
@@ -94,9 +121,10 @@ jobs:
       - run: bash scripts/smoke-test.sh https://context-vault-staging.fly.dev
 
   deploy-backend-production:
-    needs: smoke-staging
+    needs: [smoke-staging, changes]
     runs-on: ubuntu-latest
     environment: production
+    if: needs.changes.outputs.backend == 'true'
     steps:
       - uses: actions/checkout@v4
       - uses: superfly/flyctl-actions/setup-flyctl@master
@@ -105,9 +133,10 @@ jobs:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
   deploy-frontends-production:
-    needs: smoke-staging
+    needs: [smoke-staging, changes]
     runs-on: ubuntu-latest
     environment: production
+    if: needs.changes.outputs.frontends == 'true'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary

- **Fixes critical bug**: staging Vercel deploys were using `--prod` flag, which promotes to the production alias — every push to main was overwriting production Vercel deployments from staging
- **Adds path-scoping to CI**: builds for `app`, `marketing`, and `extension` are now conditional using `dorny/paths-filter`; tests always run
- **Adds path-scoping to deploy**: backend deploys only when `packages/hosted/**` or `packages/core/**` changed; frontend deploys only when `packages/app/**`, `packages/marketing/**`, or `packages/core/**` changed
- **Guards claude-code-review**: only fires on PRs that touch `packages/**` or `test/**`; skips draft PRs

## Test plan
- [ ] Verify CI workflow YAML is valid (no syntax errors)
- [ ] Verify deploy workflow YAML is valid
- [ ] Confirm staging steps do NOT have `--prod` flag
- [ ] Confirm production steps still have `--prod` flag
- [ ] Confirm `dorny/paths-filter@v3` is referenced correctly in both workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 1 queued — [View all](https://hub.continue.dev/inbox/pr/fellanH/context-vault/62?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->