### PR TITLE
chore: add branch ownership rules to all agent definitions

### DIFF
--- a/.claude/agents/cv-campaigns.md
+++ b/.claude/agents/cv-campaigns.md
@@ -113,6 +113,13 @@ Update campaign material status as you produce drafts.
 - `{top_post_title}` — best performing post
 - `{github_stars}` — current star count
 
+## Branch Ownership
+
+- **Most work is doc-only** (assets, tracker, weekly-log) — no branch needed. Commit directly or open a light `chore/gtm-<slug>` PR.
+- **If code changes are needed** (unlikely — you should not be touching packages/**): use prefix `feat/gtm-<slug>` and confirm with the user before creating the branch.
+- Before creating any branch: run `git branch` and `gh pr list` to check whether a GTM branch already exists.
+- Never touch `packages/**` directories. If you think you need to, stop and consult the user.
+
 ## Boundaries
 
 You do NOT:

--- a/.claude/agents/cv-content-writer.md
+++ b/.claude/agents/cv-content-writer.md
@@ -88,6 +88,13 @@ When asked for social media copy to accompany a blog post, write it to `docs/gtm
 - Reddit: `campaign-{letter}-reddit.md`
 - HN: `campaign-{letter}-hn.md`
 
+## Branch Ownership
+
+- **Allowed prefix:** `feat/content-<slug>` for new content, `feat/gtm-<slug>` for GTM-integrated work.
+- Your changes are limited to `packages/marketing/src/app/content/posts.ts` and `docs/gtm/assets/`.
+- Before creating a branch: run `git branch` and `gh pr list`. A content branch for the same slug may already exist.
+- After your PR merges: delete the branch locally and remotely.
+
 ## Boundaries
 
 You do NOT:

--- a/.claude/agents/cv-release-manager.md
+++ b/.claude/agents/cv-release-manager.md
@@ -57,6 +57,12 @@ After the release script pushes, verify each of these:
 - **Re-tagging after fixes:** If a fix is needed after tagging, must re-tag (`git tag -f`) and force push the tag. Always ask before doing this.
 - **Chrome Web Store review:** Extension publish may succeed but not go live immediately — pending review.
 
+## Branch Ownership
+
+- **No feature branches.** You work on a clean `main` only.
+- Before running any release: verify `git status` is clean, `gh pr list` returns empty, and `BACKLOG.md` Now section is empty.
+- If any of these checks fail: stop, report the blocker, and do not proceed with the release.
+
 ## Boundaries
 
 You do NOT:

--- a/.claude/agents/cv-sales-ops.md
+++ b/.claude/agents/cv-sales-ops.md
@@ -94,6 +94,13 @@ Store persona demos in `docs/gtm/demos/`.
 - No company names tied to specific individuals
 - If you need to reference a specific conversation, use anonymized descriptions
 
+## Branch Ownership
+
+- **Most work is doc-only** (pipeline.md, sales-playbook.md, sales-assets.md, weekly-log.md, demos/) — no branch needed. Commit directly or open a light `chore/gtm-<slug>` PR.
+- **No code changes.** You never touch `packages/**`. If you think you need to, stop and consult the user.
+- Before creating any branch: run `git branch` and `gh pr list` to check whether a GTM branch already exists.
+- After your PR merges: delete the branch locally (`git branch -d`) and remotely (`git push origin --delete`).
+
 ## Boundaries
 
 You do NOT:

--- a/.claude/agents/cv-site-dev.md
+++ b/.claude/agents/cv-site-dev.md
@@ -84,6 +84,13 @@ npm run build -w packages/marketing
 ```
 This catches TypeScript errors and ensures the build stays green.
 
+## Branch Ownership
+
+- **Allowed prefix:** `feat/marketing-<slug>`
+- Before starting work: run `git branch` and `gh pr list`. If a `feat/marketing-*` branch already exists, check its PR state before creating a new one.
+- Only commit to your assigned branch. Never commit to branches owned by other agents.
+- After your PR merges: delete the branch locally (`git branch -d`) and remotely (`git push origin --delete`).
+
 ## Boundaries
 
 You do NOT:

--- a/.claude/agents/cv-test-runner.md
+++ b/.claude/agents/cv-test-runner.md
@@ -55,6 +55,12 @@ After every test run, report:
    - **Suggested fix:** <what to change and where>
 ```
 
+## Branch Ownership
+
+- **No branches. No commits. Read-only role.**
+- You read source files and run tests. You never stage, commit, or push anything.
+- If you discover a test failure that requires a source fix, report it with a clear diagnosis — do not fix it yourself. Let the human or the appropriate engineering agent make the change.
+
 ## Boundaries
 
 You do NOT:


### PR DESCRIPTION
## Summary

Adds a `## Branch Ownership` section to all six agent definition files. Each section defines:

- The allowed branch prefix for that agent (or explicit "no branches" for read-only agents like cv-test-runner and cv-release-manager)
- Pre-work check: run `git branch` + `gh pr list` before creating a new branch
- Cleanup: delete local + remote branch after merge

This directly addresses the "agents stepping on each other's toes" problem — agents now have explicit, enforceable scope boundaries at the git level, not just at the file level.

Consistent with the branch prefix map in `DEV-PLAYBOOK.md`.

## Test plan
- [ ] Verify Branch Ownership section exists in all 6 agent files
- [ ] Verify each section is placed before the existing Boundaries section
- [ ] Verify cv-test-runner and cv-release-manager explicitly state "no branches"
- [ ] Verify cv-sales-ops section is appropriate for that agent's actual scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 1 queued — [View all](https://hub.continue.dev/inbox/pr/fellanH/context-vault/63?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->