### PR TITLE
chore: update session protocol with branch ownership + sprint tracking

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -19,6 +19,8 @@ Persistent memory layer for AI agents via MCP. Markdown files + SQLite FTS + sem
 
 Every Claude Code working session follows this workflow:
 
+> Full reference: see `DEV-PLAYBOOK.md` in the project root.
+
 ### 1. Orient
 - Read `BACKLOG.md` (engineering) or `docs/gtm/GTM-BACKLOG.md` + `docs/gtm/GTM-CONTEXT.md` (GTM)
 - Check `Now` section for active work items
@@ -33,9 +35,12 @@ Present plan for user approval **before writing code**.
 
 - **Non-trivial**: Why this/why now, 2-3 options with trade-offs, scope & risk
 - **Trivial**: One-line summary, proceed after approval
+- **Open PR check**: Run `gh pr list` before pitching. If a PR is already open, explicitly merge it, close it, or confirm you are continuing it — never silently start new work on top of an open PR.
 
 ### 4. Branch
 - Create `feat/`, `fix/`, or `chore/` branch — no direct commits to `main` (#21)
+- Branch name must encode the package scope: `feat/<scope>-<slug>` where scope = marketing | hosted | cli | extension | core | infra. See branch prefix map in `DEV-PLAYBOOK.md`.
+- One agent, one branch. Never commit to a branch owned by another agent in the same session.
 - GTM-only tasks with no code changes skip this step
 
 ### 5. Work
@@ -55,6 +60,7 @@ Present plan for user approval **before writing code**.
 End-of-session retrospective: **Shipped**, **Went well**, **Friction**, **Learned**, **Actions**.
 
 Persist: `save_context` (kind: `session-review`, tags: `context-vault, retro`). Durable lessons → memory files or CLAUDE.md. Actionable friction → issues or backlog.
+- **Branch cleanup**: delete merged branches — `git branch -d <branch>` locally and `git push origin --delete <branch>` for any branch merged this session.
 
 ### Branch naming
 | Prefix | Use |
@@ -62,6 +68,18 @@ Persist: `save_context` (kind: `session-review`, tags: `context-vault, retro`). 
 | `feat/` | New features |
 | `fix/` | Bug fixes |
 | `chore/` | Infra, deps, cleanup |
+
+### Sprint Tracking
+
+BACKLOG.md `Now` must mirror open PRs at all times:
+
+| Event | Action |
+|---|---|
+| PR opened | Move item to `Now` |
+| PR merged | Move item to `Done` |
+| PR closed without merge | Move item back to `Next` |
+
+Hard cap: 3 items in `Now`. If `Now` has an item with no matching open PR, stop and investigate before proceeding.
 
 ### Issue labels
 | Label | Purpose |


### PR DESCRIPTION
## Summary

- Adds reference to new `DEV-PLAYBOOK.md` at the top of the session protocol
- Adds open-PR check to Step 3 (Pitch): never start new work over an open PR
- Adds branch ownership rules to Step 4 (Branch): scope-encoded names, one agent one branch
- Adds branch cleanup to Step 8 (Review): delete local + remote after merge
- Adds Sprint Tracking convention: BACKLOG.md Now must mirror open PRs
- Fixes DEVELOPER.md CI/CD section: was labelling `ci.yml` as "Hosted Deploy" — the two workflows were split but docs still showed the old merged view

## Test plan
- [ ] Read CLAUDE.md and verify all five additions are present and correct
- [ ] Read DEVELOPER.md and verify CI/CD section accurately describes both workflows
- [ ] Confirm no existing content was accidentally removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 1 queued — [View all](https://hub.continue.dev/inbox/pr/fellanH/context-vault/64?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->