### PR TITLE
fix(infra): pre-compute parent SHA for deploy path filter

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,10 +31,13 @@ jobs:
         with:
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
           fetch-depth: 2
+      - name: Get parent SHA
+        id: parent
+        run: echo "sha=$(git rev-parse HEAD~1)" >> $GITHUB_OUTPUT
       - uses: dorny/paths-filter@v3
         id: filter
         with:
-          base: HEAD~1
+          base: ${{ steps.parent.outputs.sha }}
           filters: |
             backend:
               - 'packages/hosted/**'


### PR DESCRIPTION
## Problem

Every push to `main` has been failing the Deploy workflow's \`changes\` job since PR #62.

Root cause: \`dorny/paths-filter\` with \`base: HEAD~1\` tries to fetch \`HEAD~1\` as a Git refspec:
\`\`\`
git fetch --no-tags --depth=100 origin HEAD~1 main
fatal: invalid refspec 'HEAD~1'
\`\`\`
\`HEAD~1\` is a commit expression, not a refspec — you can evaluate it locally but not fetch it.

**Impact:** No deploys have run since PR #62 landed. Backend (Fly.io) and both Vercel frontends are running stale code.

## Fix

Pre-compute the parent SHA with \`git rev-parse HEAD~1\` (evaluated locally, works fine with \`fetch-depth: 2\`), then pass the resulting SHA as the base. The filter behaviour is identical — same comparison, valid input.

\`\`\`diff
+     - name: Get parent SHA
+       id: parent
+       run: echo "sha=$(git rev-parse HEAD~1)" >> $GITHUB_OUTPUT
      - uses: dorny/paths-filter@v3
        with:
-         base: HEAD~1
+         base: \${{ steps.parent.outputs.sha }}
\`\`\`

## Test plan
- [ ] CI passes on this PR
- [ ] After merge, Deploy workflow runs and \`changes\` job succeeds
- [ ] Path filter correctly skips unaffected packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 1 queued — [View all](https://hub.continue.dev/inbox/pr/fellanH/context-vault/66?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->