### PR TITLE
chore: add operational workflow scaffolding

### DIFF
--- a/.claude/hooks/protect-files.sh
+++ b/.claude/hooks/protect-files.sh
@@ -15,6 +15,7 @@ fi
 PROTECTED=(
   "packages/core/src/index/db.js"
   "scripts/release.mjs"
+  "NORTH-STAR.md"
 )
 
 for protected in "${PROTECTED[@]}"; do

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,6 +1,6 @@
 # Backlog
 
-**Last triaged:** 2026-02-20 (workflow overhaul session)
+**Last triaged:** 2026-02-21 (workflow ops session)
 
 ---
 
@@ -8,9 +8,9 @@
 
 Active work. Hard cap: 3 items. Finish or demote before adding.
 
-| Item                     | Source | Issue |
-| ------------------------ | ------ | ----- |
-| _Empty — pull from Next_ |        |       |
+| Item                                                       | Source               | Issue |
+| ---------------------------------------------------------- | -------------------- | ----- |
+| Operational workflow scaffolding (PROJECT-STATE, FEEDBACK) | workflow ops session | —     |
 
 ---
 
@@ -18,23 +18,25 @@ Active work. Hard cap: 3 items. Finish or demote before adding.
 
 _Only the latest release. Older items archived — see CHANGELOG.md and git history for full record._
 
-| Item                                                                          | Issue | Release |
-| ----------------------------------------------------------------------------- | ----- | ------- |
-| Dev playbook + guardian system (CLAUDE.md, DEV-PLAYBOOK.md, INBOX.md)         | #65   | —       |
-| Hosted dashboard for local vaults (`context-vault ui` → hosted UI)            | #61   | —       |
-| Path-scope CI/deploy workflows + fix staging `--prod` bug                     | #62   | —       |
-| Branch ownership rules in all agent definitions                               | #63   | —       |
-| Sprint tracking + branch ownership in session protocol (CLAUDE.md)            | #64   | —       |
-| Restructure reindex to separate sync DB ops from async embedding              | #29   | v2.8.0  |
-| Remove `captureAndIndex` callback indirection (always `indexEntry`)           | —     | v2.8.0  |
-| Add reindex unit test coverage (12 tests)                                     | —     | v2.8.0  |
-| Code-as-documentation overhaul (DEVELOPER.md, CLAUDE.md, archive CODE_REVIEW) | #26   | —       |
-| Split CI and deploy into separate workflows                                   | #24   | —       |
-| Paginated export for large vaults (replace load-all with limit/offset)        | #13   | —       |
-| Cache `buildUserCtx` per connection instead of per request                    | #14   | —       |
-| Add ESLint config and `tsconfig.json` to `packages/app`                       | #10   | v2.7.0  |
-| Refactor `tools.js` into individual tool handler modules                      | #11   | v2.7.0  |
-| Add JSDoc `@typedef` for `ctx` shapes per mode                                | #12   | v2.7.0  |
+| Item                                                                                    | Issue | Release |
+| --------------------------------------------------------------------------------------- | ----- | ------- |
+| Operational workflow scaffolding (PROJECT-STATE.md, FEEDBACK.md, NORTH-STAR protection) | —     | —       |
+| Configure Claude Code hooks (file protection, auto-test, stop-verify)                   | #42   | —       |
+| Dev playbook + guardian system (CLAUDE.md, DEV-PLAYBOOK.md, INBOX.md)                   | #65   | —       |
+| Hosted dashboard for local vaults (`context-vault ui` → hosted UI)                      | #61   | —       |
+| Path-scope CI/deploy workflows + fix staging `--prod` bug                               | #62   | —       |
+| Branch ownership rules in all agent definitions                                         | #63   | —       |
+| Sprint tracking + branch ownership in session protocol (CLAUDE.md)                      | #64   | —       |
+| Restructure reindex to separate sync DB ops from async embedding                        | #29   | v2.8.0  |
+| Remove `captureAndIndex` callback indirection (always `indexEntry`)                     | —     | v2.8.0  |
+| Add reindex unit test coverage (12 tests)                                               | —     | v2.8.0  |
+| Code-as-documentation overhaul (DEVELOPER.md, CLAUDE.md, archive CODE_REVIEW)           | #26   | —       |
+| Split CI and deploy into separate workflows                                             | #24   | —       |
+| Paginated export for large vaults (replace load-all with limit/offset)                  | #13   | —       |
+| Cache `buildUserCtx` per connection instead of per request                              | #14   | —       |
+| Add ESLint config and `tsconfig.json` to `packages/app`                                 | #10   | v2.7.0  |
+| Refactor `tools.js` into individual tool handler modules                                | #11   | v2.7.0  |
+| Add JSDoc `@typedef` for `ctx` shapes per mode                                          | #12   | v2.7.0  |
 
 ---
 
@@ -44,9 +46,8 @@ Ordered by ICE score (Impact × Confidence × Ease). Pull from top when `Now` ha
 
 | Item                                                                                | ICE | Source               | Issue |
 | ----------------------------------------------------------------------------------- | --- | -------------------- | ----- |
-| Configure Claude Code hooks (file protection, auto-test, orient, self-verify Stop)  | 100 | AI workflow research | —     |
-| Add `claude-code-action` workflow (PR review, issue triage, @claude mentions)       | 64  | AI workflow research | —     |
-| Add headless CI checks (duplicate constant detector, cross-package impact analysis) | 36  | AI workflow research | —     |
+| Add `claude-code-action` workflow (PR review, issue triage, @claude mentions)       | 64  | AI workflow research | #43   |
+| Add headless CI checks (duplicate constant detector, cross-package impact analysis) | 36  | AI workflow research | #51   |
 
 ---
 

--- a/FEEDBACK.md
+++ b/FEEDBACK.md
@@ -1,0 +1,15 @@
+# Feedback
+
+Real observations from using the product. Primary input for roadmap direction.
+
+**To add feedback:** `feedback: [what you experienced or noticed]`
+Agent appends it here and returns to whatever was in progress.
+
+Format: `YYYY-MM-DD [UX/DEV] — [observation]`
+Tag: `[UX]` = user experience, `[DEV]` = developer experience
+
+**Processed at triage** — agents translate entries into scored backlog items.
+
+---
+
+_No entries yet._

--- a/NORTH-STAR.md
+++ b/NORTH-STAR.md
@@ -1,0 +1,28 @@
+# North Star
+
+## What this is
+
+Context Vault is about owning your session context,  gives AI agents persistent memory. Markdown files, local SQLite,
+semantic search. Developers drop it into any Claude workflow in under 2 minutes
+and their agents remember things across sessions.
+
+## Who it's for
+
+Developers building with AI agents — especially solo builders and small teams
+who want local-first, no-cloud-dependency memory that actually works.
+The primary user is me. If it doesn't solve my own daily workflow problems,
+it doesn't ship.
+
+## What success looks like
+
+- Developers reach for it on day one of a new AI project
+- Paying users within weeks of any meaningful release, not months
+- Feedback that says "I use this every day" — not "this is interesting"
+- Revenue that compounds: each new user finds it through another user
+
+## What we don't compromise on
+
+- Local-first: the core must work without a cloud account
+- Speed of value: working in 2 minutes or it's too slow
+- Simplicity over features: one thing that works beats five things that are fine
+- Ship over perfect: real usage beats theoretical correctness every time

--- a/PROJECT-STATE.md
+++ b/PROJECT-STATE.md
@@ -1,0 +1,38 @@
+# Project State
+
+_Last updated: 2026-02-21 by chore/infra-workflow-ops_
+
+---
+
+## In Flight
+
+| Branch                   | Agent      | What                                                                                      | Started    |
+| ------------------------ | ---------- | ----------------------------------------------------------------------------------------- | ---------- |
+| chore/infra-workflow-ops | Claude CLI | Create operational workflow scaffolding (FEEDBACK.md, protect NORTH-STAR, update BACKLOG) | 2026-02-21 |
+
+---
+
+## Deployed
+
+| Package                | Version | Last deployed | Where                          |
+| ---------------------- | ------- | ------------- | ------------------------------ |
+| `packages/local` (npm) | 2.8.0   | 2026-02-20    | npmjs.com                      |
+| `packages/hosted`      | —       | 2026-02-20    | Fly.io                         |
+| `packages/app`         | —       | 2026-02-20    | Vercel (app.context-vault.com) |
+| `packages/marketing`   | —       | 2026-02-20    | Vercel (contextvault.dev)      |
+
+---
+
+## Built but not deployed
+
+_None._
+
+---
+
+## Recently completed (last 5)
+
+- 2026-02-20 — Dev playbook + guardian system (CLAUDE.md, DEV-PLAYBOOK.md, INBOX.md) (#65)
+- 2026-02-20 — Hosted dashboard for local vaults (`context-vault ui`) (#61)
+- 2026-02-20 — Path-scope CI/deploy workflows + fix staging `--prod` bug (#62)
+- 2026-02-20 — Branch ownership rules in all agent definitions (#63)
+- 2026-02-20 — Sprint tracking + branch ownership in session protocol (#64)


### PR DESCRIPTION
## Summary

- Adds `PROJECT-STATE.md` — agent-maintained live state (in-flight branches, deployed versions)
- Adds `FEEDBACK.md` — structured capture for real product observations; input to triage
- Adds `NORTH-STAR.md` — human-authored product direction anchor; agents read at session start
- Protects `NORTH-STAR.md` from agent writes in `protect-files.sh`
- Updates `BACKLOG.md`: marks Claude Code hooks as Done (already shipped), removes from Next

Closes #42

## Why

The DEV-PLAYBOOK.md self-governance checks (`Does this conflict with in-flight work? Does this serve the north star?`) had no data to run against. These files complete the operational layer.

## Test plan

- [ ] CI passes
- [ ] `protect-files.sh` blocks a write to `NORTH-STAR.md`
- [ ] `PROJECT-STATE.md` is readable at session start for orient check
- [ ] `BACKLOG.md` Now/Done/Next are consistent with open PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)