### PR TITLE
chore: update NORTH-STAR with refined product direction

### DIFF
--- a/NORTH-STAR.md
+++ b/NORTH-STAR.md
@@ -2,15 +2,15 @@
 
 ## What this is
 
-Context Vault is about owning your session context,  gives AI agents persistent memory. Markdown files, local SQLite,
-semantic search. Developers drop it into any Claude workflow in under 2 minutes
-and their agents remember things across sessions.
+Context Vault is about owning your data and storing it long term in a human readable format,  
+it allow you to give any AI agent you use now or in the future persistent memory. 
+Anyone can install it into any workflow very easily and their agents remember things across sessions.
 
 ## Who it's for
 
-Developers building with AI agents — especially solo builders and small teams
+Anyone using AI seriously — especially builders and small teams
 who want local-first, no-cloud-dependency memory that actually works.
-The primary user is me. If it doesn't solve my own daily workflow problems,
+One of the primary user is me. If it doesn't solve my own daily workflow problems,
 it doesn't ship.
 
 ## What success looks like


### PR DESCRIPTION
## Summary

Updates to NORTH-STAR.md authored by the product owner:

- **What this is**: reframed from developer/Claude-specific to owning data in human-readable format for any AI agent (past or future)
- **Who it's for**: broadened from Developers → Anyone using AI seriously

These are directional edits, not cosmetic ones — the north star now reflects a wider ICP.

## Note

NORTH-STAR.md is protected from agent writes (`protect-files.sh`). Changes here must come from the human product owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 1 queued — [View all](https://hub.continue.dev/inbox/pr/fellanH/context-vault/68?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->