### PR TITLE
feat(infra): fix claude-code-action workflows to actually post comments

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -4,8 +4,8 @@ on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
     paths:
-      - 'packages/**'
-      - 'test/**'
+      - "packages/**"
+      - "test/**"
 
 jobs:
   claude-review:
@@ -14,8 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:
@@ -29,8 +29,16 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
-          plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
+          prompt: |
+            Review this pull request for the context-vault monorepo (packages: core, local, hosted, app, marketing, extension).
+
+            Focus on:
+            1. Logic errors and correctness
+            2. Security issues (injection, auth bypass, data exposure, hardcoded secrets)
+            3. Hardcoded constants that may exist elsewhere in the repo — grep for the value across all packages before assuming it's unique (duplicate constants are a known recurring issue)
+            4. Missing test coverage for changed source files in packages/core, local, or hosted
+            5. Scope creep — files modified outside the stated purpose of the PR
+
+            Be concise. Post inline comments for specific line-level issues. End with a single summary comment: Approve / Request Changes / FYI only, with a one-line reason.
+
+            Skip style nitpicks. Skip comments on test-only changes unless the tests themselves are wrong.

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,17 +13,23 @@ on:
 jobs:
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (
+        github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'COLLABORATOR'
+      ) && (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
-      actions: read # Required for Claude to read CI results on PRs
+      actions: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -35,16 +41,3 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-
-          # This is an optional setting that allows Claude to read CI results on PRs
-          additional_permissions: |
-            actions: read
-
-          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
-          # prompt: 'Update the pull request description to include a summary of changes.'
-
-          # Optional: Add claude_args to customize behavior and configuration
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr:*)'
-


### PR DESCRIPTION
## Problem

Both Claude GitHub Action workflows existed but were silently doing nothing:

- **`claude-code-review.yml`** ran 5+ times on recent PRs and posted zero comments
- **`claude.yml`** triggered on `@claude` mentions but couldn't respond

## Root causes

1. Both workflows had `pull-requests: read` and `issues: read` — write permissions required to post comments
2. `claude-code-review.yml` used `plugin_marketplaces` + `plugins` — deprecated approach removed in v1 of the action
3. `claude.yml` had a dead `additional_permissions` block that isn't valid input syntax

## Changes

**`claude-code-review.yml`**
- `pull-requests: write`, `issues: write`
- Replaced plugin-based prompt with a direct focused `prompt` covering: logic errors, security, duplicate constants (known recurring issue), test coverage gaps, scope creep
- Stays concise: inline comments for specifics, one summary verdict

**`claude.yml`**
- `pull-requests: write`, `issues: write`
- Added `author_association` guard (`OWNER | MEMBER | COLLABORATOR`) — prevents arbitrary users on this public repo from triggering agentic runs (prompt injection mitigation)
- Removed dead `additional_permissions` block

## Test plan

- [ ] CI passes
- [ ] Next PR to `packages/**` triggers `Claude Code Review` and posts a comment
- [ ] `@claude` mention from repo owner in an issue/PR comment triggers a response

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 1 queued — [View all](https://hub.continue.dev/inbox/pr/fellanH/context-vault/70?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->