### PR TITLE
feat: bucket tag convention hints (#124)

### DIFF
--- a/packages/core/src/server/tools/get-context.js
+++ b/packages/core/src/server/tools/get-context.js
@@ -268,7 +268,9 @@ export const inputSchema = {
   tags: z
     .array(z.string())
     .optional()
-    .describe("Filter by tags (entries must match at least one)"),
+    .describe(
+      "Filter by tags (entries must match at least one). Use 'bucket:' prefixed tags for project-scoped retrieval (e.g., ['bucket:autohub']).",
+    ),
   since: z
     .string()
     .optional()

--- a/packages/core/src/server/tools/save-context.js
+++ b/packages/core/src/server/tools/save-context.js
@@ -267,7 +267,9 @@ export const inputSchema = {
   tags: z
     .array(z.string())
     .optional()
-    .describe("Tags for categorization and search"),
+    .describe(
+      "Tags for categorization and search. Use 'bucket:' prefix for project/domain scoping (e.g., 'bucket:autohub') to enable project-scoped retrieval.",
+    ),
   meta: z
     .any()
     .optional()
@@ -546,6 +548,15 @@ export async function handler(
   if (tags?.length) parts.push(`  tags: ${tags.join(", ")}`);
   parts.push(`  tier: ${effectiveTier}`);
   parts.push("", "_Use this id to update or delete later._");
+  const hasBucketTag = (tags || []).some(
+    (t) => typeof t === "string" && t.startsWith("bucket:"),
+  );
+  if (tags && tags.length > 0 && !hasBucketTag) {
+    parts.push(
+      "",
+      "_Tip: Consider adding a `bucket:` tag (e.g., `bucket:myproject`) for project-scoped retrieval._",
+    );
+  }
   if (similarEntries.length) {
     if (suggestMode) {
       const candidates = buildConflictCandidates(similarEntries);


### PR DESCRIPTION
## Summary
- Add `bucket:` prefix convention hints to `save_context` and `get_context` tool descriptions
- Soft tip appended to save response when tags are present but no `bucket:` tag is included
- Foundation for the bucket namespacing system (#122-128)

## Changes
- `save-context.js`: Updated tags schema description + added post-save bucket tag hint
- `get-context.js`: Updated tags schema description to reference `bucket:` convention

## Test plan
- [x] All 516 tests pass
- [x] Saves with `bucket:` tags see no hint
- [x] Saves without `bucket:` tags get a soft tip
- [x] Saves with no tags see no hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)