### PR TITLE
feat(core): hot-reload config.json without server restart

### DIFF
--- a/packages/local/src/server/index.js
+++ b/packages/local/src/server/index.js
@@ -150,6 +150,7 @@ async function main() {
             `[context-vault] Config reloaded: vaultDir changed to ${fresh.vaultDir}`,
           );
           lastVaultDir = fresh.vaultDir;
+          fresh.vaultDirExists = existsSync(fresh.vaultDir);
         }
         return fresh;
       },


### PR DESCRIPTION
## Summary
- Replaces the static `ctx.config` with a getter that calls `resolveConfig()` on every tool call, so changes to `~/.context-mcp/config.json` take effect immediately without restarting Claude Code
- Logs to stderr when `vaultDir` changes mid-session: `[context-vault] Config reloaded: vaultDir changed to /path`
- Adds 4 unit tests verifying the hot-reload pattern (vaultDir pickup, destructured snapshot isolation, resolvedFrom accuracy, eventDecayDays reload)

## Implementation
Option C from the issue — re-read config on every tool call. `resolveConfig()` reads a ~200-byte JSON file, which is negligible compared to SQLite queries and embedding operations that follow.

The `Object.defineProperty` getter on `ctx.config` means tools that destructure `const { config } = ctx;` get a fresh config snapshot once per call, with no changes needed to any tool handler.

Closes #144

## Test plan
- [x] New `test/unit/config-hot-reload.test.js` — 4 tests covering core reload behavior
- [x] All existing tests pass (146/146 in config + tool-handler suites)
- [ ] Manual: change `vaultDir` in `~/.context-mcp/config.json` while server is running, verify `context_status` shows updated path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 1 queued — [View all](https://hub.continue.dev/inbox/pr/fellanH/context-vault/147?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->