### PR TITLE
fix(cli): wire --identity-key and --meta flags in save command

### DIFF
--- a/packages/local/bin/cli.js
+++ b/packages/local/bin/cli.js
@@ -3598,6 +3598,8 @@ async function runSave() {
   const tier = getFlag("--tier");
   const filePath = getFlag("--file");
   const bodyFlag = getFlag("--body");
+  const identityKey = getFlag("--identity-key");
+  const metaRaw = getFlag("--meta");
 
   if (!kind) {
     console.error(red("Error: --kind is required"));
@@ -3606,6 +3608,16 @@ async function runSave() {
   if (!title) {
     console.error(red("Error: --title is required"));
     process.exit(1);
+  }
+
+  let meta;
+  if (metaRaw) {
+    try {
+      meta = JSON.parse(metaRaw);
+    } catch {
+      console.error(red("Error: --meta must be valid JSON"));
+      process.exit(1);
+    }
   }
 
   let body;
@@ -3665,6 +3677,8 @@ async function runSave() {
       tags: parsedTags,
       source,
       ...(tier ? { tier } : {}),
+      ...(identityKey ? { identity_key: identityKey } : {}),
+      ...(meta !== undefined ? { meta } : {}),
     });
     console.log(`${green("✓")} Saved ${kind} — id: ${entry.id}`);
   } catch (e) {


### PR DESCRIPTION
## Summary
- `runSave()` now reads `--identity-key` and `--meta` flags from CLI args
- `--meta` is parsed as JSON with a clear error on invalid input
- Both flags are passed through to `captureAndIndex()`
- Previously these flags were silently dropped, causing dedup failures

Fixes fellanH/omni#127

## Test plan
- [x] `context-vault save --identity-key "test:123"` now persists the identity key
- [x] `context-vault save --meta '{"foo":"bar"}'` now persists metadata
- [x] Invalid JSON for `--meta` shows a clear error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 1 queued — [View all](https://hub.continue.dev/inbox/pr/fellanH/context-vault/189?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->